### PR TITLE
windows rocket push/pull fix

### DIFF
--- a/modbase/src/game/w_saber.c
+++ b/modbase/src/game/w_saber.c
@@ -35,7 +35,13 @@ void WP_SaberAddG2Model( gentity_t *saberent, const char *saberModel, qhandle_t 
 void WP_SaberRemoveG2Model( gentity_t *saberent );
 
 float RandFloat(float min, float max) {
-	return ((rand() * (max - min)) / 32768.0F) + min;
+// sil - bugging for identical behaviour on windows
+// (might need tweaking for different compilers)
+	int random = rand();
+#ifndef __GCC__
+	random = (random << 16) | random; 
+#endif	
+	return ((random * (max - min)) / 32768.0F) + min;
 }
 
 #ifdef DEBUG_SABER_BOX

--- a/modbase/src/game/w_saber.c
+++ b/modbase/src/game/w_saber.c
@@ -34,14 +34,13 @@ qboolean WP_SaberBladeDoTransitionDamage( saberInfo_t *saber, int bladeNum );
 void WP_SaberAddG2Model( gentity_t *saberent, const char *saberModel, qhandle_t saberSkin );
 void WP_SaberRemoveG2Model( gentity_t *saberent );
 
+// sil - "fix" for identical behaviour on windows
 float RandFloat(float min, float max) {
-// sil - bugging for identical behaviour on windows
-// (might need tweaking for different compilers)
 	int random = rand();
-#ifndef __GCC__
+#if RAND_MAX < 2147483647
 	random = (random << 16) | random; 
-#endif	
-	return ((random * (max - min)) / 32768.0F) + min;
+#endif
+	return ((random * (max - min)) / 32768.0F) + min; 
 }
 
 #ifdef DEBUG_SABER_BOX


### PR DESCRIPTION
Fixed (bugged) behaviour on windows in RandFloat() function. Defined for "not GCC compilers", should be generally used for any compiler that has RAND_MAX below 2^31. Real fix would be to change linux behaviour but that is not recognized as a standard in jka :(. 
